### PR TITLE
Consume websocket apis

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 src/**/*-test.js
+src/utils/websocket.js

--- a/src/models/engineimage.js
+++ b/src/models/engineimage.js
@@ -1,4 +1,5 @@
 import { create, deleteEngineImage, query } from '../services/engineimage'
+import { wsChanges } from '../utils/websocket'
 import { parse } from 'qs'
 
 export default {
@@ -15,6 +16,7 @@ export default {
           payload: location.query,
         })
       })
+      wsChanges(dispatch, 'engineimages', '1s')
     },
   },
   effects: {
@@ -22,6 +24,16 @@ export default {
       payload,
     }, { call, put }) {
       const data = yield call(query, parse(payload))
+      if (payload && payload.field && payload.keyword) {
+        data.data = data.data.filter(item => item[payload.field].indexOf(payload.keyword.trim()) > -1)
+      }
+      data.data.sort((a, b) => a.image.localeCompare(b.image))
+      yield put({ type: 'queryEngineimage', payload: { ...data } })
+    },
+    *updateBackground({
+      payload,
+    }, { put }) {
+      const data = payload
       if (payload && payload.field && payload.keyword) {
         data.data = data.data.filter(item => item[payload.field].indexOf(payload.keyword.trim()) > -1)
       }

--- a/src/models/host.js
+++ b/src/models/host.js
@@ -1,4 +1,5 @@
 import { query, toggleScheduling, updateDisk } from '../services/host'
+import { wsChanges } from '../utils/websocket'
 import { parse } from 'qs'
 
 export default {
@@ -18,6 +19,7 @@ export default {
           payload: location.query,
         })
       })
+      wsChanges(dispatch, 'nodes', '1s')
     },
   },
   effects: {
@@ -26,6 +28,12 @@ export default {
     }, { call, put }) {
       const data = yield call(query, parse(payload))
       data.data.sort((a, b) => a.name.localeCompare(b.name))
+      yield put({ type: 'queryHost', payload: { ...data } })
+    },
+    *updateBackground({
+      payload,
+    }, { put }) {
+      const data = payload
       yield put({ type: 'queryHost', payload: { ...data } })
     },
     *toggleScheduling({

--- a/src/models/setting.js
+++ b/src/models/setting.js
@@ -1,4 +1,5 @@
 import { query, update } from '../services/setting'
+import { wsChanges } from '../utils/websocket'
 import { parse } from 'qs'
 
 export default {
@@ -15,6 +16,7 @@ export default {
           payload: location.query,
         })
       })
+      wsChanges(dispatch, 'settings', '1s')
     },
   },
   effects: {
@@ -35,6 +37,10 @@ export default {
       }
       yield put({ type: 'query' })
       yield put({ type: 'hideSaving' })
+    },
+    *updateBackground({ payload }, { put }) {
+      const data = payload
+      yield put({ type: 'querySetting', payload: { ...data } })
     },
   },
   reducers: {

--- a/src/models/volume.js
+++ b/src/models/volume.js
@@ -1,4 +1,5 @@
 import { create, deleteVolume, query, execAction, recurringUpdate } from '../services/volume'
+import { wsChanges } from '../utils/websocket'
 import { sortVolumeByName } from '../utils/sort'
 import { parse } from 'qs'
 
@@ -27,6 +28,7 @@ export default {
           })
         }
       })
+      wsChanges(dispatch, 'volumes', '1s')
     },
   },
   effects: {
@@ -44,6 +46,20 @@ export default {
       sortVolumeByName(data.data)
       yield put({ type: 'queryVolume', payload: { ...data } })
       yield put({ type: 'clearSelection' })
+    },
+    *updateBackground({
+      payload,
+    }, { put }) {
+      const data = payload
+      if (payload && payload.field === 'id' && payload.keyword) {
+        data.data = data.data.filter(item => item[payload.field].indexOf(payload.keyword) > -1)
+      }
+      if (payload && payload.field === 'host' && payload.keyword) {
+        data.data = data.data.filter(item => item.controller && item.controller.hostId
+          && payload.keyword.split(',').indexOf(item.controller.hostId) > -1)
+      }
+      sortVolumeByName(data.data)
+      yield put({ type: 'queryVolume', payload: { ...data } })
     },
     *engineUpgrade({
       payload,

--- a/src/utils/websocket.js
+++ b/src/utils/websocket.js
@@ -1,0 +1,28 @@
+function constructWebsocketURL(type, period) {
+  let loc = window.location
+
+  let proto = 'ws:'
+  if (loc.protocol === 'https:') {
+    proto = 'wss:'
+  }
+
+  // FIXME this should be derived from LONGHORN_MANAGER_IP
+  let host = '127.0.0.1:9500'
+  // the local dev server doesn't forward websockets correctly so we bypass it
+  if (loc.host !== 'localhost:8000') {
+    host = loc.host
+  }
+
+  return `${proto}//${host}/v1/ws/${period}/${type}`
+}
+
+export function wsChanges(dispatch, type, period) {
+  let url = constructWebsocketURL(type, period)
+  const ws = new WebSocket(url)
+  ws.onmessage = function (msg) {
+    dispatch({
+      type: 'updateBackground',
+      payload: JSON.parse(msg.data),
+    })
+  }
+}


### PR DESCRIPTION
Issues:
* Inbound websocket changes cause user input to be erased. This is particularly annoying for modal popups which close/reopen, losing all state.
* roadhog dev server doesn't forward websockets (need layer 4 forwarding), workaround should be to ignore CORS and create sockets directly to LONGHORN_MANAGER_IP - currently hardcoded to 127.0.0.1