### PR TITLE
handling storage value in node page

### DIFF
--- a/src/routes/dashboard/components/resourceOverview.js
+++ b/src/routes/dashboard/components/resourceOverview.js
@@ -65,11 +65,12 @@ class ResourceOverview extends React.Component {
     // Available (green)
     // a. AvailableForSchedulingStorage = sum(enabledNodes.enabledDisks.AvailableStorage - enabledNodes.enabledDisks.ReservedStorage)
     const computeSchedulableSpace = () => {
-      return host.data.filter(n => n.allowScheduling === true).reduce((total, currentNode) => {
+      const result = host.data.filter(n => n.allowScheduling === true).reduce((total, currentNode) => {
         return total + Object.values(currentNode.disks).filter(d => d.allowScheduling === true).reduce((availabeSpace, currentDisk) => {
           return availabeSpace + (currentDisk.storageAvailable - currentDisk.storageReserved)
         }, 0)
       }, 0)
+      return result < 0 ? 0 : result
     }
     // Used (blue)
     // a. UsedStorage = sum(enabledNodes.enabledDisk.MaximumStorage - enabledNodes.enabledDisks.AvailableStorage)

--- a/src/routes/host/HostList.js
+++ b/src/routes/host/HostList.js
@@ -177,7 +177,7 @@ class List extends React.Component {
           const total = computeSize(record)
           return (
             <div>
-              <div>{formatMib(total)}</div>
+              <div>{formatMib(total < 0 ? 0 : total)}</div>
               <div className={styles.secondLabel} style={{ color: '#b9b9b9', height: '22px' }}>{reserved > 0 ? `+${formatMib(reserved)} Reserved` : null}</div>
             </div>
           )

--- a/src/routes/host/helper/index.js
+++ b/src/routes/host/helper/index.js
@@ -13,7 +13,7 @@ export function byteToGi(value) {
 
 export function giToByte(value) {
   const val = Number(value)
-  return val * 1024 * 1024 * 1024
+  return Math.round(val * 1024 * 1024 * 1024)
 }
 
 export function getStorageProgressStatus(minimalSchedulingQuotaWarning, percent) {

--- a/src/routes/volume/detail/VolumeInfo.js
+++ b/src/routes/volume/detail/VolumeInfo.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react'
 import { Row, Col, Alert, Icon } from 'antd'
 import moment from 'moment'
 import classnames from 'classnames'
-import { formatMib } from '../../../utils/formater'
+import { formatMib, utcStrToDate } from '../../../utils/formater'
 import { isSchedulingFailure, getHealthState, needToWaitDone, frontends } from '../helper/index'
 import styles from './VolumeInfo.less'
 import LatestBackup from './LatestBackup'
@@ -68,7 +68,7 @@ function VolumeInfo({ clearBackupStatus, backupStatus, selectedVolume, queryBack
       </div>
       <div className={styles.row}>
         <span className={styles.label}> Created:</span>
-        {moment(new Date(selectedVolume.created)).fromNow()}
+        {moment(utcStrToDate(selectedVolume.created)).fromNow()}
       </div>
       <div className={styles.row}>
         <Row>


### PR DESCRIPTION
1.Due to user umount disk, reset node size to 0 instead of negative value
2.Rounding the storage value in edit disk modal, due to Gi to byte may appear as decimals 
3.volume create time show invalid date in volume detail page non-chrome browser
4.reset schedulabe value to 0 if schedulable space is negative number in dashboard page