### PR TITLE
tooltip covered dropdown menu on snapshot tree in some cases

### DIFF
--- a/src/components/Snapshot/Snapshot.js
+++ b/src/components/Snapshot/Snapshot.js
@@ -66,7 +66,7 @@ function SnapshotIcon(props, snapshotProps) {
       trigger={props.removed ? [] : ['click']}
       key={props.name}
     >
-      <Tooltip placement="top" autoAdjustOverflow={false} title={<div>
+      <Tooltip placement="right" autoAdjustOverflow={false} title={<div>
         <p className="snapshot-name">Name: {props.name}</p>
         <p className="snapshot-created">Created: {props.created}</p>
         <p className="snapshot-name">Size: {formatMib(props.size)}</p>


### PR DESCRIPTION
the Tooltip covered dropdown menu on snapshot tree in some cases:
The space below is too small or the space above is too small
